### PR TITLE
fix: bump helm chart mongodb version

### DIFF
--- a/kubernetes/helm/smilr/Chart.yaml
+++ b/kubernetes/helm/smilr/Chart.yaml
@@ -16,4 +16,4 @@ dependencies:
   - name: mongodb
     repository: https://charts.bitnami.com/bitnami
     condition: mongodb.enabled
-    version: 10.x.x
+    version: 13.x.x


### PR DESCRIPTION
The mongodb chart with v10 is not available anymore, so I have tested v13 and it works fine.